### PR TITLE
backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,30 @@
-var partial = function() {
-  var _args = Array.from(arguments);
-	var fn = _args[0];
-  var args = _args.slice(1);
-	return function() {
-		if (arguments.length + args.length >= fn.length) {
-      var x = args.concat(Array.from(arguments));
-			return fn(...x);
-		} else {	
-      var x = args.concat(Array.from(arguments));
-			return partial(fn,...x)
-		}
-	};
-};
-partial.rapply = function() {
-  var _args = Array.from(arguments);
-	var fn = _args[0];
-  var args = _args.slice(1);
-	return function() {
-		if ((arguments.length + args.length) >= fn.length) {
-      var x = Array.from(arguments).concat(args);
-			return fn(...x);
-		} else {	
-      var x = Array.from(arguments).concat(args);
-			return partial.rapply(fn,...x);
-		}
-	};
-};
-var exports = module.exports = partial;
+var slice = Array.prototype.slice
+
+module.exports = partial
+partial.rapply = rapply
+
+function partial(fn) {
+  var bound = slice.call(arguments, 1)
+  return function () {
+    var args = bound.concat(slice.call(arguments))
+    if (args.length < fn.length) {
+      args.unshift(fn)
+      return partial.apply(this, args)
+    } else {
+      return fn.apply(this, args)
+    }
+  }
+}
+
+function rapply(fn) {
+  var bound = slice.call(arguments, 1)
+  return function () {
+    var args = slice.call(arguments).concat(bound)
+    if (args.length < fn.length) {
+      args.unshift(fn)
+      return rapply.apply(this, args)
+    } else {
+      return fn.apply(this, args)
+    }
+  }
+}


### PR DESCRIPTION
hi, found this package earlier and noticed spreads and `Array.from` :grimacing:

also apparently [cloning `arguments` natively is slow](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments), but the fix is fairly verbose; either way, i didn't really see much of a speed difference personally. Your call ¯\\\_(ツ)_/¯